### PR TITLE
Security parameters: Make identity and algorithm optional, add ID

### DIFF
--- a/ietf-taps-api.yang
+++ b/ietf-taps-api.yang
@@ -421,7 +421,12 @@ module ietf-taps-api {
     container security {
       description "Security properties for the connection";
       list credentials {
-        key "identity algorithm";
+        key "id";
+
+        leaf id {
+          type string;
+          description "id of the remote endpoint";
+        }
 
         uses security-credentials;
         description "security credentials";


### PR DESCRIPTION
Using TLS, a server has to specify its identity, but a client does not have to. Therefore, the identity should be optional.
The algorithm should be optional, too, because it's contained in the identity, if the identity is provided as a certificate. (The API draft does not specify in what format the identity should be provided, but it also does not contain explicit metadata for the identity such as algorithms. So perhaps it's okay to have a single certificate file or other object that represents the identity including all its metadata.)